### PR TITLE
Fix code scanning alert no. 4: Use of externally-controlled format string

### DIFF
--- a/storage/src/main/java/com/github/advancedsecurity/storageservice/controllers/BlobController.java
+++ b/storage/src/main/java/com/github/advancedsecurity/storageservice/controllers/BlobController.java
@@ -48,7 +48,7 @@ public class BlobController {
             // var path = String.format("%s/%s", profile.name, id.toString());
             var path = String.format("%s", id);
 
-                System.out.format(id + "-local", path );
+                System.out.format("%s-local", id);
 
             var stat = minio.statObject(
                 StatObjectArgs


### PR DESCRIPTION
Fixes [https://github.com/octobooth/mona-gallery/security/code-scanning/4](https://github.com/octobooth/mona-gallery/security/code-scanning/4)

To fix the problem, we should avoid using the user-provided `id` directly in the format string. Instead, we can use a placeholder (`%s`) in the format string and pass the `id` as an argument. This ensures that any format specifiers in the `id` are not interpreted by the `System.out.format` method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
