### PR TITLE
Fix 2 code scanning alerts

### DIFF
--- a/gallery/main.go
+++ b/gallery/main.go
@@ -657,7 +657,7 @@ func authnMiddleware(next http.Handler) http.Handler {
 
 		if strings.HasPrefix(authz, "Bearer") {
 			tokenString := strings.TrimSpace(strings.TrimPrefix(authz, "Bearer"))
-			log.Printf("AuthN: Received bearer token %s", tokenString)
+			log.Printf("AuthN: Received bearer token %s", maskToken(tokenString))
 			token, err := jwt.ParseWithClaims(tokenString, &OctoClaims{}, func(token *jwt.Token) (interface{}, error) {
 				// Don't forget to validate the alg is what you expect:
 				//if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
@@ -669,13 +669,13 @@ func authnMiddleware(next http.Handler) http.Handler {
 			})
 
 			if err != nil {
-				log.Printf("AuthN: Invalid token %s", err)
+				log.Printf("AuthN: Invalid token")
 				http.Error(w, "Forbidden", http.StatusForbidden)
 				return
 			}
 
 			if claims, ok := token.Claims.(*OctoClaims); ok && token.Valid {
-				log.Printf("AuthN: Received valid token %s", authz)
+				log.Printf("AuthN: Received valid token")
 
 				log.Printf("AuthN: Adding %s %s", GitHubLoginHeader, claims.Profile.Login)
 				r.Header.Add(GitHubLoginHeader.String(), claims.Profile.Login)


### PR DESCRIPTION
Fixes 2 code scanning alerts:
- https://github.com/octobooth/mona-gallery/security/code-scanning/6
To fix the problem, we should avoid logging the sensitive bearer token directly. Instead, we can log a masked version of the token or omit it entirely from the logs. This way, we maintain the ability to debug while protecting sensitive information.

  - We will modify the logging statements to either mask the sensitive parts of the token or remove the token from the logs.
  - Specifically, we will change the logging on line 660 to log a masked version of the token.
  - We will also review other logging statements to ensure no sensitive information is logged.
  


- https://github.com/octobooth/mona-gallery/security/code-scanning/5
To fix the problem, we should avoid logging the bearer token in clear text. Instead, we can log a masked version of the token or omit it entirely. This will ensure that sensitive information is not exposed in the logs.

  - We will modify the logging statement on line 660 to log a masked version of the `tokenString`.
  - We will introduce a helper function to mask the token, showing only the first and last few characters and replacing the middle part with asterisks.
  


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._